### PR TITLE
Fix permission item identification reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com), and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [1.0.2] - 25-04-2025
+
+- Fixed incorrect item identification reference format in permission retrieve script.
+
 ## [1.0.1] - 14-03-2025
 
 - Updated permission retrieve script and removed the `DisplayName` from the reference.

--- a/permissions/groups/permissions.ps1
+++ b/permissions/groups/permissions.ps1
@@ -62,7 +62,9 @@ try {
         $outputContext.Permissions.Add(
             @{
                 DisplayName    = $permission.Naam
-                Identification = $permission.Referentie
+                Identification = @{
+                    Reference = $permission.Referentie
+                }
             }
         )
     }


### PR DESCRIPTION
 - The permission item's identification reference does not follow the [documented format](https://docs.helloid.com/en/provisioning/target-systems/powershell-v2-target-systems/permissions/retrieve-permissions-script.html) and causes HelloID to error when retrieving permissions.
 - This partially reverts #2, which instead should have changed the used property.

---

The changelog was updated as this seems to be a requirement and new releases are created automatically. You can push to the branch if the version/release date needs to be different.